### PR TITLE
Add checkbox support

### DIFF
--- a/calculation/static/calculation/js/calculation.js
+++ b/calculation/static/calculation/js/calculation.js
@@ -124,18 +124,33 @@
             return deleted;
         },
         _getUnmaskedValue(element) {
-            let value = element.hasOwnProperty('inputmask') ? element.inputmask.unmaskedvalue() : element.value;
-            return element.hasOwnProperty('inputmask') ? value.toString().replace(',', '.') : value;
+            let value = element.inputmask.unmaskedvalue();
+            return value.toString().replace(',', '.');
+        },
+        _getValue: function(element) {
+            if (element.hasOwnProperty('inputmask')){
+                return this._getUnmaskedValue(element);
+            }else{
+                if (element.type == 'checkbox'){
+                    return element.checked;
+                }else{
+                    return element.value;
+                }
+            }
         },
         _getValues: function () {
             let values = [];
             if (this.summaryFields.length > 0) {
                 let that = this;
                 this.summaryFields.forEach(function (element) {
-                    let value = that._getUnmaskedValue(element);
+                    let value = that._getValue(element);
                     let deleted = that._isFormSetRowDeleted(element);
-                    if (value.length > 0 && deleted === false) {
-                        values.push(parseFloat(value));
+                    if (typeof value != "boolean") {
+                        if (value.length > 0 && deleted === false) {
+                            values.push(parseFloat(value));
+                        }
+                    }else{
+                        values.push(value);
                     }
                 });
             }
@@ -160,7 +175,7 @@
                 let parsedFormula = this.definition.formula;
                 for (let [key, value] of Object.entries(this.fieldsInFormula)) {
                     let name = this.isFormSet ? value.element.name.replaceAll(this.formSetKey, "") : value.element.name;
-                    parsedFormula = parsedFormula.replaceAll(name, this._getUnmaskedValue(value.element));
+                    parsedFormula = parsedFormula.replaceAll(name, this._getValue(value.element));
                 };
                 try {
                     this.field.value = eval(parsedFormula);
@@ -301,10 +316,19 @@
         calculatedSrcFields.forEach(function (element) {
             if (element) {
                 if (mode === 'add'){
-                    element.addEventListener("blur", handleBlurCb);
+                    if (element.type == 'checkbox'){
+                        element.addEventListener("change", handleBlurCb);
+                    }else{
+                        element.addEventListener("blur", handleBlurCb);
+                    }
                 }
                 if (mode === 'remove'){
-                    element.removeEventListener("blur", handleBlurCb);
+                    if (element.type == 'checkbox'){
+                        element.removeEventListener("change", handleBlurCb);
+                    }else{
+                        element.removeEventListener("blur", handleBlurCb);
+                    }
+                    
                 }
             }
         });

--- a/calculation/static/calculation/js/calculation.js
+++ b/calculation/static/calculation/js/calculation.js
@@ -79,7 +79,9 @@
             let rawList = this.definition.formula.match(regexp);
             if (rawList) {
                 // TODO: move to regexp
-                rawList = rawList.filter(function(e){return e != 'this'});
+                rawList = rawList.filter(function (e) {
+                    return e != 'this'
+                });
                 for (let index = 0; index < rawList.length; index++) {
                     let name = this.isFormSet ? `${this.formSetKey}${rawList[index]}` : rawList[index];
                     let field = this.parent.querySelector('input[name=' + name + ']');
@@ -127,13 +129,13 @@
             let value = element.inputmask.unmaskedvalue();
             return value.toString().replace(',', '.');
         },
-        _getValue: function(element) {
-            if (element.hasOwnProperty('inputmask')){
+        _getValue: function (element) {
+            if (element.hasOwnProperty('inputmask')) {
                 return this._getUnmaskedValue(element);
-            }else{
-                if (element.type == 'checkbox'){
+            } else {
+                if (element.type == 'checkbox') {
                     return element.checked;
-                }else{
+                } else {
                     return element.value;
                 }
             }
@@ -149,7 +151,7 @@
                         if (value.length > 0 && deleted === false) {
                             values.push(parseFloat(value));
                         }
-                    }else{
+                    } else {
                         values.push(value);
                     }
                 });
@@ -305,8 +307,8 @@
             obj.executeAll();
         }
     }
-    
-    
+
+
     /**
      *   Configure: add or remove events
      *   
@@ -315,20 +317,20 @@
     function configureEvents(mode) {
         calculatedSrcFields.forEach(function (element) {
             if (element) {
-                if (mode === 'add'){
-                    if (element.type == 'checkbox'){
+                if (mode === 'add') {
+                    if (element.type == 'checkbox') {
                         element.addEventListener("change", handleBlurCb);
-                    }else{
+                    } else {
                         element.addEventListener("blur", handleBlurCb);
                     }
                 }
-                if (mode === 'remove'){
-                    if (element.type == 'checkbox'){
+                if (mode === 'remove') {
+                    if (element.type == 'checkbox') {
                         element.removeEventListener("change", handleBlurCb);
-                    }else{
+                    } else {
                         element.removeEventListener("blur", handleBlurCb);
                     }
-                    
+
                 }
             }
         });
@@ -340,16 +342,16 @@
         });
         formsetDeleteButtons.forEach(function (element) {
             if (element) {
-                if (mode === 'add'){
-                    element.addEventListener("change", handleBlurCb);   
+                if (mode === 'add') {
+                    element.addEventListener("change", handleBlurCb);
                 }
-                if (mode === 'remove'){
+                if (mode === 'remove') {
                     element.removeEventListener("change", handleBlurCb);
                 }
             }
         });
     };
-    
+
     function addEvents() {
         configureEvents('add');
     }
@@ -358,9 +360,9 @@
         configureEvents('remove');
     }
 
-    function findDynamicFormsets(){
+    function findDynamicFormsets() {
         let elements = document.querySelectorAll("[data-formset-prefix]");
-        elements.forEach(function(element){
+        elements.forEach(function (element) {
             let obj = {
                 "prefix": element.getAttribute('data-formset-prefix'),
                 "containerElement": element
@@ -368,8 +370,8 @@
             dynamicFormsets.push(obj);
         });
     }
-    
-    function configure(){
+
+    function configure() {
         const fields = document.querySelectorAll("input[data-calculation]");
         fields.forEach(function (field) {
             let instance = new CalculatedField(field.getAttribute("id"));
@@ -379,10 +381,10 @@
         resolveDependencies();
         sortExecution();
         findSrcFields();
-        addEvents();        
+        addEvents();
     }
-    
-    window.resetCalculatedFields = function(){
+
+    window.resetCalculatedFields = function () {
         removeEvents();
         calculatedFields = [];
         calculatedSrcFields = [];

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ setup(
     name="django-calculation",
     packages=["calculation"],
     include_package_data=True,
-    version="0.0.9",
+    version="0.0.10",
     description="A Django app to make simple calculations in your django forms",
     long_description=open("README.md").read(),
 	long_description_content_type="text/markdown",


### PR DESCRIPTION
With this update, a checkbox can be referenced from a formula.

When a checkbox is referenced, `django-calculation` will return its `checked` attribute instead of the value. With that, it is possible to use conditional expressions that require the state of a checkbox.

Example:

Tax application if checkbox is checked.

```python
...
amount = forms.DecimalField()
apply_taxes = forms.BooleanField(initial=True)
tax = forms.DecimalField(
    widget=calculation.FormulaInput('apply_taxes ? amount/11 : 0.0')
)
```

